### PR TITLE
Use str.trim() instead of str.replace(/^\s+|\s+$/g, '')

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ var through2 = require('through2');
 var EE = require('events').EventEmitter;
 var gutil = require('gulp-util');
 
-function trim(str) { return str.replace(/^\s+|\s+$/g, ''); }
-
 function removeDefaultHandler(stream, event) {
     var found = false;
     stream.listeners(event).forEach(function (item) {
@@ -34,7 +32,7 @@ function defaultErrorHandler(error) {
     if (EE.listenerCount(this, 'error') < 3) {
         gutil.log(
             gutil.colors.cyan('Plumber') + ' found unhandled error:',
-            gutil.colors.red(trim(error.toString())));
+            gutil.colors.red(error.toString().trim()));
     }
 }
 


### PR DESCRIPTION
It behaves exactly same

References:
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim
