### PR TITLE
Add Node.js v4 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - '0.10'
-  - '0.11'
+  - '0.12'
+  - '4'
 after_script:
   - npm run coveralls


### PR DESCRIPTION
Probably a good idea to test against the latest stable version of Node.js.

I also swapped out v0.11 for v0.12, since it is the "official" successor to v0.10. But I can revert that line if you want.